### PR TITLE
Change regex pattern to match image files.

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -39,7 +39,7 @@ var baguetteBox = (function() {
     // If set to true ignore touch events because animation was already fired
     var touchFlag = false;
     // Regex pattern to match image files
-    var regex = /.+\.(gif|jpe?g|png|webp)$/i;
+    var regex = /.+\.(gif|jpe?g|png|webp)/i;
     // Array of all used galleries (DOM elements)
     var galleries = [];
     // 2D array of galleries and images inside them


### PR DESCRIPTION
I've just made [image formatter for Drupal](https://www.drupal.org/project/baguettebox) based on this library. Everything works fine for existing images. But it doesn't work if we are dealing with derivative images that are not cached yet. For security reasons Drupal requires special image token to be presented in url.
