### PR TITLE
added feature 'removeButtonsAfter'

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -3,6 +3,9 @@
  * @author  feimosi
  * @version 1.4.2
  * @url https://github.com/feimosi/baguetteBox.js
+ *
+ * modified by H.Lo 2016-01-16
+ * - added 'removeButtonsAfter' to 'options'
  */
 
 (function (root, factory) {
@@ -33,6 +36,8 @@
     var options = {}, defaults = {
         captions: true,
         buttons: 'auto',
+        // idle time in milliseconds to remove navigation buttons and close button; showing again after mouse move
+        removeButtonsAfter: null,
         async: false,
         preload: 2,
         animation: 'slideIn',
@@ -61,6 +66,8 @@
     var imagesElements = [];
     // Event handlers
     var imagedEventHandlers = {};
+    // Event handler for remove icons option
+    var hideNavigationSetTimeoutHandle = null;
     var overlayClickHandler = function(event) {
         // When clicked on the overlay (outside displayed image) close it
         if(event.target && event.target.nodeName !== 'IMG' && event.target.nodeName !== 'FIGCAPTION')
@@ -103,6 +110,15 @@
     };
     var touchendHandler = function(event) {
         touchFlag = false;
+    };
+
+    // the state of navigation buttons and close button
+    var navigationVisible = true;
+
+    // here storing mouse position to be able to check if mouse really moved - mousemove event is called sometimes when mouse not moved
+    var mousePos = {
+        x : null,
+        y : null
     };
 
     // forEach polyfill for IE8
@@ -288,6 +304,9 @@
             options.buttons = false;
         // Set buttons style to hide or display them
         previousButton.style.display = nextButton.style.display = (options.buttons ? '' : 'none');
+        // add mousemove event listener only if option is set
+        if(options.removeButtonsAfter)
+            window.addEventListener('mousemove', mousemove);
     }
 
     function showOverlay(chosenImageIndex) {
@@ -309,8 +328,42 @@
             if(options.afterShow)
                 options.afterShow();
         }, 50);
+        if(options.removeButtonsAfter)
+            resetHideIconsTimeout();
         if(options.onChange)
             options.onChange(currentIndex, imagesElements.length);
+    }
+
+    function mousemove(event) {
+        if(mousePos.x === event.pageX && mousePos.y === event.pageY)
+            return;
+        mousePos.x = event.pageX;
+        mousePos.y = event.pageY;
+        showNavigation();
+        clearTimeout(hideNavigationSetTimeoutHandle);
+        hideNavigationSetTimeoutHandle = setTimeout(function() { hideNavigation(); }, options.removeButtonsAfter);
+    }
+
+    function setNavigationDisplayProperty(val) {
+        closeButton.style.display = val;
+        previousButton.style.display = val;
+        nextButton.style.display = val;
+    }
+
+    function hideNavigation() {
+        if(navigationVisible === true) {
+            clearTimeout(hideNavigationSetTimeoutHandle);
+            setNavigationDisplayProperty('none');
+            navigationVisible = false;
+        }
+    }
+
+    function showNavigation() {
+        if(navigationVisible === false) {
+            clearTimeout(hideNavigationSetTimeoutHandle);
+            setNavigationDisplayProperty('block');
+            navigationVisible = true;
+        }
     }
 
     function hideOverlay() {
@@ -417,9 +470,16 @@
             }, 400);
             returnValue = false;
         }
+        if(options.removeButtonsAfter)
+            resetHideIconsTimeout();
         if(options.onChange)
             options.onChange(currentIndex, imagesElements.length);
         return returnValue;
+    }
+
+    function resetHideIconsTimeout() {
+        clearTimeout(hideNavigationSetTimeoutHandle);
+        hideNavigationSetTimeoutHandle = setTimeout(hideNavigation, options.removeButtonsAfter);
     }
 
     // Return false at the left end of the gallery
@@ -438,6 +498,8 @@
             }, 400);
             returnValue = false;
         }
+        if(options.removeButtonsAfter)
+            resetHideIconsTimeout();
         if(options.onChange)
             options.onChange(currentIndex, imagesElements.length);
         return returnValue;


### PR DESCRIPTION
Added option to remove navigation buttons (prev, next, close) after X milliseconds.
Very handy for users using keyboard navigation - no need for buttons.
Navigation is shown right after mouse move.
Disabled by default.
Configurable using options object during initialization.