### PR TITLE
Make the `buttons` accessible.

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -219,19 +219,23 @@
         // Create all necessary buttons
         previousButton = create('button');
         previousButton.id = 'previous-button';
+        previousButton.setAttribute('aria-label', 'Previous');
         previousButton.innerHTML = supports.svg ? leftArrow : '&lt;';
         overlay.appendChild(previousButton);
 
         nextButton = create('button');
         nextButton.id = 'next-button';
+        nextButton.setAttribute('aria-label', 'Next');
         nextButton.innerHTML = supports.svg ? rightArrow : '&gt;';
         overlay.appendChild(nextButton);
 
         closeButton = create('button');
         closeButton.id = 'close-button';
-        closeButton.innerHTML = supports.svg ? closeX : 'X';
+        closeButton.setAttribute('aria-label', 'Close');
+        closeButton.innerHTML = supports.svg ? closeX : '&times';
         overlay.appendChild(closeButton);
 
+        previousButton.type = nextButton.type = closeButton.type = 'button';
         previousButton.className = nextButton.className = closeButton.className = 'baguetteBox-button';
 
         bindEvents();


### PR DESCRIPTION
Also switch to `&times;` instead of a simple `X` for the fallback close button.

Tested things with https://github.com/squizlabs/HTML_CodeSniffer, but I think we hit https://github.com/squizlabs/HTML_CodeSniffer/issues/160 for the remaining ones.