### PR TITLE
Guard against missing currentGallery element

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -484,8 +484,15 @@
             return;
         }
 
+        var galleryItem = currentGallery[index];
+        // It's possible that the decision to preload is made,
+        // but by the time the load happens, the element is gone.
+        if (typeof galleryItem  === 'undefined') {
+            return;
+        }
+
         // Get element reference, optional caption and source path
-        var imageElement = currentGallery[index].imageElement;
+        var imageElement = galleryItem.imageElement;
         var thumbnailElement = imageElement.getElementsByTagName('img')[0];
         var imageCaption = typeof options.captions === 'function' ?
                             options.captions.call(currentGallery, imageElement) :

--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -472,7 +472,11 @@
 
     function loadImage(index, callback) {
         var imageContainer = imagesElements[index];
-        if (typeof imageContainer === 'undefined') {
+        var galleryItem = currentGallery[index];
+
+        // Return if the index exceeds prepared images in the overlay
+        // or if the current gallery has been changed / closed
+        if (imageContainer === undefined || galleryItem === undefined) {
             return;
         }
 
@@ -481,13 +485,6 @@
             if (callback) {
                 callback();
             }
-            return;
-        }
-
-        var galleryItem = currentGallery[index];
-        // It's possible that the decision to preload is made,
-        // but by the time the load happens, the element is gone.
-        if (typeof galleryItem  === 'undefined') {
             return;
         }
 


### PR DESCRIPTION
When an image is loaded,
it can preload the next/previous image with a callback.
It's possible that between when the decision to preload is made
and the `loadImage` call for preloading happens,
the current gallery has been modified and the index to preload
is missing, causing the preload callback to error.

---

I can't say _exactly_ why this is occurring, but each day we get at least one error on this line, with a stacktrace coming from `preloadNext` or `preloadPrev`, and this change appears to fix it. I decided to not invoke the callback in the case the chosen item is missing from the current gallery, since that's what you do on line 474 (if `imagesElements[index]` is undefined). But since I can't create a reliable repro, I could use your judgement here.