### PR TITLE
Added options to enable customization of ARIA labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The following options are available:
 | --- | --- | --- | --- |
 | `captions` | `Boolean` \| `function(element)` | `true` | Display image captions. Passing a function will use a string returned by this callback. The only argument is `a` element containing the image. Invoked in the context of the current gallery array |
 | `buttons` | `Boolean` \| `'auto'` | `'auto'` | Display buttons. `'auto'` hides buttons on touch-enabled devices or when only one image is available |
+| `previousButtonLabel`, `nextButtonLabel`, `closeButtonLabel` | `String` | `'Previous'`, `'Next'`, `'Close'` | ARIA label of buttons |
 | `fullScreen` | `Boolean` | `false` | Enable full screen mode |
 | `noScrollbars` | `Boolean` | `false` | Hide scrollbars when gallery is displayed |
 | `bodyClass` | `String` | `'baguetteBox-open'` | Class name that will be appended to the `body` when lightbox is visible (works in IE 10+) |

--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -38,6 +38,9 @@
         defaults = {
             captions: true,
             buttons: 'auto',
+            previousButtonLabel: 'Previous',
+            nextButtonLabel: 'Next',
+            closeButtonLabel: 'Close',
             fullScreen: false,
             noScrollbars: false,
             bodyClass: 'baguetteBox-open',
@@ -273,21 +276,18 @@
         previousButton = create('button');
         previousButton.setAttribute('type', 'button');
         previousButton.id = 'previous-button';
-        previousButton.setAttribute('aria-label', 'Previous');
         previousButton.innerHTML = supports.svg ? leftArrow : '&lt;';
         overlay.appendChild(previousButton);
 
         nextButton = create('button');
         nextButton.setAttribute('type', 'button');
         nextButton.id = 'next-button';
-        nextButton.setAttribute('aria-label', 'Next');
         nextButton.innerHTML = supports.svg ? rightArrow : '&gt;';
         overlay.appendChild(nextButton);
 
         closeButton = create('button');
         closeButton.setAttribute('type', 'button');
         closeButton.id = 'close-button';
-        closeButton.setAttribute('aria-label', 'Close');
         closeButton.innerHTML = supports.svg ? closeX : '&times;';
         overlay.appendChild(closeButton);
 
@@ -388,6 +388,10 @@
         }
         // Set buttons style to hide or display them
         previousButton.style.display = nextButton.style.display = (options.buttons ? '' : 'none');
+        // Set buttons' aria-labels
+        previousButton.setAttribute('aria-label', options.previousButtonLabel);
+        nextButton.setAttribute('aria-label', options.nextButtonLabel);
+        closeButton.setAttribute('aria-label', options.closeButtonLabel);
         // Set overlay color
         try {
             overlay.style.backgroundColor = options.overlayBackgroundColor;


### PR DESCRIPTION
This pull request extends the options object with the attributes previousButtonLabel, nextButtonLabel and closeButtonLabel. It enables customization of aria-labels of the three buttons, and allows users to translate the strings to their own languages.
Feature request #108 is related, but that feature is not implemented in this commit.