### PR TITLE
Add option for custom buttons

### DIFF
--- a/src/baguetteBox.js
+++ b/src/baguetteBox.js
@@ -48,7 +48,10 @@
             afterShow: null,
             afterHide: null,
             onChange: null,
-            overlayBackgroundColor: 'rgba(0,0,0,.8)'
+            overlayBackgroundColor: 'rgba(0,0,0,.8)',
+            closeX: closeX,
+            leftArrow: leftArrow,
+            rightArrow: rightArrow
         };
     // Object containing information about features compatibility
     var supports = {};
@@ -398,6 +401,12 @@
         }
         // Set buttons style to hide or display them
         previousButton.style.display = nextButton.style.display = (options.buttons ? '' : 'none');
+        // Set custom markup for buttons
+        closeButton.innerHTML = options.closeX;
+        if (options.buttons) {
+            previousButton.innerHTML = options.leftArrow;
+            nextButton.innerHTML = options.rightArrow;
+        }
         // Set overlay color
         try {
             overlay.style.backgroundColor = options.overlayBackgroundColor;


### PR DESCRIPTION
Add support for custom buttons.
Resolving #35

New options: `leftArrow`, `rightArrow`, `closeX`

```js
    baguetteBox.run('.baguetteBox', {
        leftArrow : '...',
        rightArrow : '...',
        closeX : '...'
    });
```

All options must be valid SVG markup.
The buttons will be updated inside `setOptions` by setting `innerHTML` on the button element(s).

If no options are passed the default buttons will be used.

Works with multiple instances of `baguetteBox`  - like in the demo.
You're able to customize the galleries separately unlike #204.

Thank you for considering this contribution.