### PR TITLE
Create composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ bower install baguettebox.js --save
 <script src="js/baguetteBox.min.js" async></script>
   ```
 
+### Composer
+Add the following to your `composer.json` file (updating the version as required) and then run `composer install` or `composer update`:
+
+```json
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/feimosi/baguetteBox.js"
+        }
+    ],
+    "require": {
+        "feimosi/baguettebox.js": "dev-main"
+    }
+}
+```
+
 ## Importing
 
 ### Traditional approach

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "feimosi/baguettebox.js",
+    "description": "Simple and easy to use lightbox script",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "feimosi",
+            "homepage": "https://github.com/feimosi"
+        }
+    ],
+    "homepage": "https://github.com/feimosi/baguetteBox.js",
+    "keywords": ["lightbox", "gallery", "image", "javascript"],
+    "minimum-stability": "stable",
+    "require": {},
+    "autoload": {
+        "classmap": ["dist/"]
+    }
+}


### PR DESCRIPTION
This PR adds a basic `composer.json` file so that the project can be installed in PHP projects as a Composer dependency. It sets it up to install from the GitHub repository, so publishing to Packagist is not required.

An example of how to add the package to a project's Composer dependencies is included in a README update as well.