### PR TITLE
Add a counter

### DIFF
--- a/dist/baguetteBox.js
+++ b/dist/baguetteBox.js
@@ -536,11 +536,16 @@
         // Get element reference, optional caption and source path
         var imageElement = galleryItem.imageElement;
         var thumbnailElement = imageElement.getElementsByTagName('img')[0];
-        var imageCaption = typeof options.captions === 'function' ?
-            options.captions.call(currentGallery, imageElement) :
-            imageElement.getAttribute('data-caption') || imageElement.title;
+       // var imageCaption = typeof options.captions === 'function' ?
+        //    options.captions.call(currentGallery, imageElement) :
+        //    imageElement.getAttribute('data-caption') || imageElement.title;
         var imageSrc = getImageSrc(imageElement);
-
+        
+        /***change caption en compteur****/
+		var actuel = [index +1] ;
+		var imageCaption = actuel +'/' + currentGallery.length;
+		/******************************/
+        
         // Prepare figure element
         var figure = create('figure');
         figure.id = 'baguetteBox-figure-' + index;


### PR DESCRIPTION
My photos do not have “data-caption.” I wanted to set up a counter in the style of “photo index number/total photos in the gallery.”
<img width="1469" height="788" alt="Capture du 2026-03-10 06-46-31" src="https://github.com/user-attachments/assets/2449c3ef-1e70-4501-b27f-20614c432ef8" />
